### PR TITLE
Use blueprint-compiler from runtime and more

### DIFF
--- a/dev.mufeed.Wordbook.json
+++ b/dev.mufeed.Wordbook.json
@@ -12,28 +12,16 @@
     "--socket=wayland"
   ],
   "cleanup": [
-    "*blueprint*",
-    "*.a",
-    "*.la",
+    "/include",
     "/lib/pkgconfig",
-    "/include"
+    "/share/vim",
+    "*.la",
+    "*.a"
+  ],
+  "cleanup-commands": [
+    "python3 -m compileall --invalidation-mode=unchecked-hash /app"
   ],
   "modules": [
-    {
-      "name": "blueprint-compiler",
-      "buildsystem": "meson",
-      "cleanup": [
-        "*"
-      ],
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://gitlab.gnome.org/GNOME/blueprint-compiler",
-          "tag": "v0.20.4",
-          "commit": "31b62c24a72c1670d2d93dcdf2d130f1ae12778e"
-        }
-      ]
-    },
     {
       "name": "pcaudiolib",
       "sources": [


### PR DESCRIPTION
- Use the blueprint-compiler module from the runtime
- Improve cleanup commands to reduce the Flatpak size
- Compile pyc files to improve performance